### PR TITLE
Add support for pg_timestampz with UTC offsets

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [{backoff, "~> 1.1.6"},
-        {pg_types, "~> 0.4.0"},
+        {pg_types, "~> 0.5.0"},
         {opentelemetry_api, "~> 1.4.0"}]}.
 
 {profiles, [{test, [{erl_opts, [nowarn_export_all]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,14 @@
 {"1.2.0",
 [{<<"backoff">>,{pkg,<<"backoff">>,<<"1.1.6">>},0},
- {<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.4.0">>},0}]}.
+ {<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.4.0">>},0},
+ {<<"pg_types">>,{pkg,<<"pg_types">>,<<"0.5.0">>},0}]}.
 [
 {pkg_hash,[
  {<<"backoff">>, <<"83B72ED2108BA1EE8F7D1C22E0B4A00CFE3593A67DBC792799E8CCE9F42F796B">>},
- {<<"opentelemetry_api">>, <<"63CA1742F92F00059298F478048DFB826F4B20D49534493D6919A0DB39B6DB04">>}]},
+ {<<"opentelemetry_api">>, <<"63CA1742F92F00059298F478048DFB826F4B20D49534493D6919A0DB39B6DB04">>},
+ {<<"pg_types">>, <<"4FF09A61231EF33A10CF9524CECF8696EA2C971EE89204F95ACEFB1CFE9682DB">>}]},
 {pkg_hash_ext,[
  {<<"backoff">>, <<"CF0CFFF8995FB20562F822E5CC47D8CCF664C5ECDC26A684CBE85C225F9D7C39">>},
- {<<"opentelemetry_api">>, <<"3DFBBFAA2C2ED3121C5C483162836C4F9027DEF469C41578AF5EF32589FCFC58">>}]}
+ {<<"opentelemetry_api">>, <<"3DFBBFAA2C2ED3121C5C483162836C4F9027DEF469C41578AF5EF32589FCFC58">>},
+ {<<"pg_types">>, <<"A3023B464AA960BC1628635081E30CCA4F676F2D4C23CCD6179C1C11C9B4A642">>}]}
 ].

--- a/src/pgo.erl
+++ b/src/pgo.erl
@@ -22,10 +22,7 @@
          checkout/2,
          checkin/2,
          break/1,
-         format_error/1,
-        string_to_hex_list/2,
-        hex_list_to_data/1
-        ]).
+         format_error/1]).
 
 
 -include("pgo_internal.hrl").
@@ -35,14 +32,6 @@
               error/0,
               pool_config/0,
               decode_fun/0]).
-
-string_to_hex_list([O, T | Rest], Acc) ->
-    string_to_hex_list(Rest, Acc ++ [[O, T]]);
-string_to_hex_list([], Acc) ->
-    Acc.
-
-hex_list_to_data(HexList) ->
-    << <<(list_to_integer(H, 16))>> || H <- HexList >>.
 
 -type result() :: #{command := atom(),
                     num_rows := integer() | table,

--- a/src/pgo.erl
+++ b/src/pgo.erl
@@ -22,7 +22,11 @@
          checkout/2,
          checkin/2,
          break/1,
-         format_error/1]).
+         format_error/1,
+        string_to_hex_list/2,
+        hex_list_to_data/1
+        ]).
+
 
 -include("pgo_internal.hrl").
 -include_lib("opentelemetry_api/include/otel_tracer.hrl").
@@ -31,6 +35,14 @@
               error/0,
               pool_config/0,
               decode_fun/0]).
+
+string_to_hex_list([O, T | Rest], Acc) ->
+    string_to_hex_list(Rest, Acc ++ [[O, T]]);
+string_to_hex_list([], Acc) ->
+    Acc.
+
+hex_list_to_data(HexList) ->
+    << <<(list_to_integer(H, 16))>> || H <- HexList >>.
 
 -type result() :: #{command := atom(),
                     num_rows := integer() | table,

--- a/src/pgo.erl
+++ b/src/pgo.erl
@@ -24,7 +24,6 @@
          break/1,
          format_error/1]).
 
-
 -include("pgo_internal.hrl").
 -include_lib("opentelemetry_api/include/otel_tracer.hrl").
 

--- a/test/pgo_datetime_SUITE.erl
+++ b/test/pgo_datetime_SUITE.erl
@@ -9,7 +9,7 @@ all() ->
     [{group, erl_datetime}, {group, as_integer}, {group, as_float}, {group, as_micro}].
 
 groups() ->
-    [{erl_datetime, [], [select, insert, interval, timezone]},
+    [{erl_datetime, [], [select, insert, interval, timestamptz]},
      {as_micro, [], [as_micro]},
      {as_integer, [], [as_integer]},
      {as_float, [], [as_float]}].
@@ -167,14 +167,14 @@ as_micro(_Config) ->
                    rows := [{1326797643450000, 1326797643450000}]},
                  pgo:query("select a_timestamp, b_timestamp from times")).
 
-timezone(_Config) ->
+timestamptz(_Config) ->
     ?assertMatch(#{command := create},
-                 pgo:query("create temporary table timezone_table (a_timestamp timestamptz)")),
+                 pgo:query("create temporary table timestamptz_table (a_timestamp_with_timezone timestamptz)")),
 
     ?assertMatch(#{command := insert},
-                 pgo:query("insert into timezone_table (a_timestamp) VALUES ($1)",
-                           [{{2012,1,17},{10,54,3.45},-4}])),
+                 pgo:query("insert into timestamptz_table (a_timestamp_with_timezone) VALUES ($1)",
+                           [{{2012,1,17},{10,54,3.45},{-4, 15}}])),
 
     ?assertMatch(#{command := select,
-                   rows := [{{{2012,1,17},{6,54,3.45}}}]},
-                pgo:query("select a_timestamp from timezone_table")).
+                   rows := [{{{2012,1,17},{15,9,3.45}}}]},
+                pgo:query("select a_timestamp_with_timezone from timestamptz_table")).

--- a/test/pgo_datetime_SUITE.erl
+++ b/test/pgo_datetime_SUITE.erl
@@ -9,7 +9,7 @@ all() ->
     [{group, erl_datetime}, {group, as_integer}, {group, as_float}, {group, as_micro}].
 
 groups() ->
-    [{erl_datetime, [], [select, insert, interval]},
+    [{erl_datetime, [], [select, insert, interval, timezone]},
      {as_micro, [], [as_micro]},
      {as_integer, [], [as_integer]},
      {as_float, [], [as_float]}].
@@ -166,3 +166,15 @@ as_micro(_Config) ->
     ?assertMatch(#{command := select,
                    rows := [{1326797643450000, 1326797643450000}]},
                  pgo:query("select a_timestamp, b_timestamp from times")).
+
+timezone(_Config) ->
+    ?assertMatch(#{command := create},
+                 pgo:query("create temporary table timezone_table (a_timestamp timestamptz)")),
+
+    ?assertMatch(#{command := insert},
+                 pgo:query("insert into timezone_table (a_timestamp) VALUES ($1)",
+                           [{{2012,1,17},{10,54,3.45},-4}])), % EDT timezone
+
+    ?assertMatch(#{command := select,
+                   rows := [1326812043450000]},
+                pgo:query("select a_timestamp from timezone_table")).

--- a/test/pgo_datetime_SUITE.erl
+++ b/test/pgo_datetime_SUITE.erl
@@ -173,8 +173,8 @@ timezone(_Config) ->
 
     ?assertMatch(#{command := insert},
                  pgo:query("insert into timezone_table (a_timestamp) VALUES ($1)",
-                           [{{2012,1,17},{10,54,3.45},-4}])). % EDT timezone
+                           [{{2012,1,17},{10,54,3.45},-4}])),
 
-    %% ?assertMatch(#{command := select,
-    %%                rows := [1326812043450000]},
-    %%             pgo:query("select a_timestamp from timezone_table")).
+    ?assertMatch(#{command := select,
+                   rows := [{{{2012,1,17},{6,54,3.45}}}]},
+                pgo:query("select a_timestamp from timezone_table")).

--- a/test/pgo_datetime_SUITE.erl
+++ b/test/pgo_datetime_SUITE.erl
@@ -173,8 +173,8 @@ timezone(_Config) ->
 
     ?assertMatch(#{command := insert},
                  pgo:query("insert into timezone_table (a_timestamp) VALUES ($1)",
-                           [{{2012,1,17},{10,54,3.45},-4}])), % EDT timezone
+                           [{{2012,1,17},{10,54,3.45},-4}])). % EDT timezone
 
-    ?assertMatch(#{command := select,
-                   rows := [1326812043450000]},
-                pgo:query("select a_timestamp from timezone_table")).
+    %% ?assertMatch(#{command := select,
+    %%                rows := [1326812043450000]},
+    %%             pgo:query("select a_timestamp from timezone_table")).

--- a/test/pgo_datetime_SUITE.erl
+++ b/test/pgo_datetime_SUITE.erl
@@ -171,7 +171,6 @@ timestamptz(_Config) ->
     ?assertMatch(#{command := create},
                  pgo:query("create temporary table timestamptz_table (a_timestamp_with_timezone timestamptz)")),
 
-
     % Negative minute offsets are not allowed by pg_types
     % Hour offsets are technically limited over the wire, but the library
     % handles conversion so we don't have limitations on the hour offset

--- a/test/pgo_datetime_SUITE.erl
+++ b/test/pgo_datetime_SUITE.erl
@@ -171,6 +171,14 @@ timestamptz(_Config) ->
     ?assertMatch(#{command := create},
                  pgo:query("create temporary table timestamptz_table (a_timestamp_with_timezone timestamptz)")),
 
+
+    % Negative minute offsets are not allowed by pg_types
+    % Hour offsets are technically limited over the wire, but the library
+    % handles conversion so we don't have limitations on the hour offset
+    ?assertMatch({error, #{error := badarg_encoding}},
+                 pgo:query("insert into timestamptz_table (a_timestamp_with_timezone) VALUES ($1)",
+                           [{{2012,1,17},{10,54,3.45},{-4, -15}}])),
+
     ?assertMatch(#{command := insert},
                  pgo:query("insert into timestamptz_table (a_timestamp_with_timezone) VALUES ($1)",
                            [{{2012,1,17},{10,54,3.45},{-4, 15}}])),


### PR DESCRIPTION
In this PR, I expose the timestamptz encoding of pg_types by simply bumping the version. I additionally add some tests to show the limitations.