### PR TITLE
fix: use setops helper for ssl connections

### DIFF
--- a/src/pgo_handler.erl
+++ b/src/pgo_handler.erl
@@ -585,7 +585,7 @@ flush_until_ready_for_query(Result, Conn=#conn{owner=Pid,
             gen_statem:cast(Pid, {set_parameter, Name, Value}),
             flush_until_ready_for_query(Result, Conn#conn{parameters=Parameters#{Name => Value}});
         {ok, #ready_for_query{}} ->
-            _ = inet:setopts(Socket, [{active, once}]),
+            _ = setopts(SocketModule, Socket, [{active, once}]),
             Result;
         {ok, _OtherMessage} ->
             flush_until_ready_for_query(Result, Conn);


### PR DESCRIPTION
We were seeing this error in prod. using pog (for gleam bindings) to pgo. pgo was on version 0.17.0.

```
EROR label=GenStatem(Terminate) name=//erl(<0.1814.0>) reason=Error(FunctionClause, [PrimInet(Setopts, [Sslsocket(//erl(#Port<0.414>), //erl(<0.1817.0>), //erl(<0.1816.0>), GenTcp, TlsGenConnection, //erl(#Ref<0.1647852057.3898474498.41957>), Undefined), [Active(Once)]], []), PgoHandler(FlushUntilReadyForQuery, 2, [File(charlist.from_string("/build/packages/server/build/prod/erlang/pgo/src/pgo_handler.erl")), Line(588)]) 

...etc
```

I believe this fixes it