### PR TITLE
fix: improve type specs for downstream type checkers

### DIFF
--- a/src/pgo.erl
+++ b/src/pgo.erl
@@ -29,12 +29,16 @@
 
 -export_type([result/0,
               error/0,
+              pool/0,
+              row/0,
+              options/0,
               pool_config/0,
-              decode_fun/0]).
+              decode_fun/0,
+              decode_option/0]).
 
 -type result() :: #{command := atom(),
-                    num_rows := integer() | table,
-                    rows := list()} | {error, error()} | {error, any()}.
+                    num_rows := non_neg_integer() | table,
+                    rows := [row()]} | {error, error()} | {error, any()}.
 
 -type error() :: {pgo_error, #{error_field() => binary()}} | pg_types:encoding_error().
 
@@ -219,16 +223,16 @@ with_conn(Conn, Fun) ->
     end.
 
 %% @doc Returns a connection from the pool.
--spec checkout(atom()) -> {ok, pgo_pool:pool_ref(), pgo_pool:conn()} | {error, any()}.
+-spec checkout(atom()) -> {ok, pgo_pool:ref(), pgo_pool:conn()} | {error, any()}.
 checkout(Pool) ->
     pgo_pool:checkout(Pool, []).
 
--spec checkout(atom(), [pool_option()]) -> {ok, pgo_pool:pool_ref(), pgo_pool:conn()} | {error, any()}.
+-spec checkout(atom(), [pool_option()]) -> {ok, pgo_pool:ref(), pgo_pool:conn()} | {error, any()}.
 checkout(Pool, Options) ->
     pgo_pool:checkout(Pool, Options).
 
 %% @doc Return a checked out connection to its pool
--spec checkin(pgo_pool:pool_ref(), pgo_pool:conn()) -> ok.
+-spec checkin(pgo_pool:ref(), pgo_pool:conn()) -> ok.
 checkin(Ref, Conn) ->
     pgo_pool:checkin(Ref, Conn, []).
 


### PR DESCRIPTION
## Summary

Improves type specifications in `pgo.erl` for better compatibility with gradual type checkers (eqWAlizer, Dialyzer):

- **Export additional types**: `pool/0`, `row/0`, `options/0`, `decode_option/0` — these are referenced in downstream code but weren't exported
- **Fix `result()` type**: `rows` field typed as `[row()]` instead of bare `list()`, `num_rows` typed as `non_neg_integer()` instead of `integer()`
- **Fix `checkout`/`checkin` specs**: Use `pgo_pool:ref()` instead of `pgo_pool:pool_ref/0` which doesn't exist (the exported type is `ref/0`)

## Motivation

When using pgo with eqWAlizer (WhatsApp's gradual type checker for Erlang), the untyped `rows := list()` and missing type exports cause cascading type errors in every downstream project. These changes are backwards-compatible and make the types more precise.

## Test plan

- [x] `rebar3 compile` — passes
- [x] `rebar3 eunit` — 2 tests pass
- [x] `rebar3 dialyzer` — passes