### PR TITLE
Handle tcp_closed the same as ssl_closed in pgo_connection

### DIFF
--- a/src/pgo_connection.erl
+++ b/src/pgo_connection.erl
@@ -21,6 +21,10 @@
          format_status/1,
          terminate/3]).
 
+-ifdef(TEST).
+-export([handle_event/3]).
+-endif.
+
 -include("pgo_internal.hrl").
 -include_lib("kernel/include/logger.hrl").
 
@@ -184,6 +188,9 @@ handle_event(info, {'EXIT', Socket, _Reason}, Data=#data{conn=#conn{socket=Socke
     close_and_reopen(Data);
 %% ignore `EXIT' for a different Socket -- means it is an old message
 handle_event(info, {'EXIT', _, _Reason}, _Data) ->
+    keep_state_and_data;
+%% nothing to do for `tcp_closed' -- it should be handled by the `EXIT' handling
+handle_event(info, {tcp_closed, _}, _Data) ->
     keep_state_and_data;
 %% nothing to do for `ssl_closed' -- it should be handled by the `EXIT' handling
 handle_event(info, {ssl_closed, _}, _Data) ->

--- a/test/pgo_connection_test.erl
+++ b/test/pgo_connection_test.erl
@@ -1,0 +1,14 @@
+-module(pgo_connection_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% tcp_closed/ssl_closed are informational only -- the real disconnect
+%% handling happens via the linked socket's `EXIT` message. Before this fix,
+%% `tcp_closed` had no matching clause and crashed the connection process
+%% with `function_clause` (only `ssl_closed` was handled), which the
+%% supervisor then restarted. Both must be ignored the same way.
+tcp_closed_is_ignored_test() ->
+    ?assertEqual(keep_state_and_data, pgo_connection:handle_event(info, {tcp_closed, some_port}, undefined)).
+
+ssl_closed_is_ignored_test() ->
+    ?assertEqual(keep_state_and_data, pgo_connection:handle_event(info, {ssl_closed, some_port}, undefined)).


### PR DESCRIPTION
## Summary
`pgo_connection`'s `handle_event/3` catch-all has a clause that ignores `ssl_closed` info messages (the comment explains the real disconnect handling happens via the linked socket's `EXIT` message), but there was no equivalent clause for `tcp_closed` on plain, non-SSL connections. That meant any TCP-closed notification crashed the connection process with `function_clause`, e.g. `[{pgo_connection,handle_event,[info,{tcp_closed,#Port<...>},...]}]`, which the supervisor then restarts. Self-healing, not an outage, but needless churn and noisy crash reports under any connection pattern where something server-side closes idle sockets, a connection pooler recycling idle backend connections being the common case.

This adds the missing `tcp_closed` clause with the identical treatment `ssl_closed` already gets.

## Test plan
- [x] `rebar3 eunit` - new `pgo_connection_test.erl` asserts both `tcp_closed` and `ssl_closed` return `keep_state_and_data`; confirmed the new test fails without the fix (reverted locally, both failed) and passes with it
- [x] `rebar3 xref` clean
- Confirmed live: seen repeatedly against a pooled Postgres connection in a production deployment