### PR TITLE
fix: row() is a tuple by default, never a list

### DIFF
--- a/src/pgo.erl
+++ b/src/pgo.erl
@@ -44,7 +44,7 @@
 
 -type pool() :: atom().
 
--type row() :: list() | map().
+-type row() :: tuple() | map().
 -type fields() :: [#row_description_field{}].
 -type decode_fun() :: fun((row(), fields()) -> row()) | undefined.
 

--- a/src/pgo_protocol.erl
+++ b/src/pgo_protocol.erl
@@ -573,7 +573,7 @@ decode_strings(Binary) ->
 %%--------------------------------------------------------------------
 %% @doc Decode a row format.
 %%
--spec decode_row([#row_description_field{}], [binary()], atom(), proplists:proplist()) -> tuple().
+-spec decode_row([#row_description_field{}], [binary()], atom(), proplists:proplist()) -> pgo:row().
 decode_row(Descs, Values, OIDMap, DecodeOptions) ->
     case proplists:get_bool(return_rows_as_maps, DecodeOptions) of
         false ->


### PR DESCRIPTION
Fixes #134. Also resolves #130.

`pgo_protocol:decode_row/4` builds a row with `list_to_tuple/1` unless `return_rows_as_maps` is set, so a row is a tuple by default and a map under that option. It is never a list, but `pgo:row/0` says `list() | map()`.

Because `result()` is `rows := [row()]`, that wrong element type reaches every consumer, and a correct match such as `#{rows := [{<<"true">>}]}` is reported by dialyzer as a pattern that can never match. #134 has a self-contained reproduction.

Two lines:

- `pgo:row/0` becomes `tuple() | map()`.
- `decode_row/4` returns `pgo:row()` instead of `tuple()`, so the decoder points at the canonical type rather than restating it. That also covers the map case it can already return, which is what #130 reports.

## Effect

`rebar3 as test dialyzer` on this repo, OTP 29.0.2:

| | warnings | of which "can never match" |
| --- | --- | --- |
| 36efee8 | 135 | 43 |
| this branch | 9 | 0 |

The remaining 9 are unrelated and pre-existing (`pgo_sasl_prep_profile`, `pgo_scram`, a `pool_config()` contract in a suite, and an `otel_span:end_span/2` contract). `rebar3 xref` and `rebar3 dialyzer` on the default profile are clean.

No runtime change, and no change to what any function actually returns.

## Not included

#134 also notes that `{dialyzer, [{warnings, [no_unknown]}]}` in `rebar.config` hides six dangling remote type references (including the one #128 ran into). That is a separate change with its own fallout, so it is left out of this PR. Happy to send it separately if wanted.
